### PR TITLE
Add cli tools useful for work with OpenShift cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ ENV GLIBC_VERSION=2.31-r0 \
     OC_VERSION=4.3.3 \
     KUBECTL_VERSION=v1.18.3
 
-# plugin executes the commands relying on Bash
 RUN apk add --update --no-cache bash && \
+    ln -sf /bin/bash /bin/sh && \
+    echo "source /etc/profile.d/bash_completion.sh" >> ~/.bashrc && \
     # install glibc compatibility layer package for Alpine Linux
     # see https://github.com/openshift/origin/issues/18942 for the details
     wget -O glibc-${GLIBC_VERSION}.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -17,7 +17,9 @@ export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 
 if ! whoami >/dev/null 2>&1; then
-    echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/sh" >> /etc/passwd
+  echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+else
+  sed -i "s/\(.*:.*:${USER_ID}:${GROUP_ID}:.*:.*:\).*/\1\/bin\/bash/" /etc/passwd
 fi
 
 # Grant access to projects volume in case of non root user with sudo rights


### PR DESCRIPTION
### What does this PR do?
This PR add a ferw tools which may be usefull for work with OpenShift cluster:
1. Default sh now is set to bash with completion
2. kubens + kubectx.
3. curl
4. jq
5. yq

New image is 108mb bigger:
![Screenshot_20200529_105129](https://user-images.githubusercontent.com/5887312/83235463-954b5880-a19a-11ea-814f-a4d2c8c3c4dc.png)

### Which issue does this PR reference?
It's done for https://github.com/eclipse/che/issues/16938
I'm not sure it should be part of upstream `che-sidecar-openshift-connector`
maybe it should be only in command-line-terminal specific container. It's why it's a draft.

### How to test this PR?
Play with + jq + yq + curl, kubens + kubectx completion in built image `docker run -ti sleshchenko/openshift-plugin:cluster-tools bash`

![Screenshot_20200528_133249](https://user-images.githubusercontent.com/5887312/83131651-d8e58a00-a0e8-11ea-9e32-a9c40ae57ac9.png)
